### PR TITLE
Refactor Client

### DIFF
--- a/lib/batches.js
+++ b/lib/batches.js
@@ -8,14 +8,12 @@ class Batches {
 
   verify(emails, options = {}) {
     return this.client.makePostRequest(
-      'post', 'batch', Object.assign({}, { emails: emails.join(',') }, options)
+      'batch', { emails: emails.join(','), ...options }
     );
   }
 
   status(id, options = {}) {
-    return this.client.makeRequest(
-      'get', 'batch', Object.assign({}, { id: id }, options)
-    );
+    return this.client.makeGetRequest('batch', { id: id, ...options });
   }
 
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,62 +5,42 @@ const axios = require('axios');
 class Client {
 
   constructor(key) {
-    this.key = key;
+    this.instance = axios.create({ baseURL: 'https://api.emailable.com/v1/' });
+    if (key) {
+      this.instance.defaults.headers.common['Authorization'] = `Bearer ${key}`;
+    }
   }
 
-  makeRequest(method, endpoint, params = {}, transformResponse) {
-
-    params = Object.assign(params, { api_key: this.key })
-
+  makeGetRequest(endpoint, params = {}) {
     return new Promise((resolve, reject) => {
+      this.instance.get(endpoint, { params: params })
+        .then(response => resolve(response.data))
+        .catch(error => {
+          if (error.response) {
+            reject({
+              message: error.response.data.message,
+              code: error.response.status
+            })
+          } else {
+            reject({ message: error });
+          }
+        });
+    });
+  };
 
-      axios({
-        method: method,
-        url: `https://api.emailable.com/v1/${endpoint}`,
-        params: params,
-        transformResponse: transformResponse
-      })
-      .then(response => {
-        resolve(response.data);
-      })
-      .catch(error => {
-        if (error.response) {
+  makePostRequest(endpoint, data = {}) {
+    return new Promise((resolve, reject) => {
+      this.instance.post(endpoint, data)
+        .then(response => resolve(response.data))
+        .catch(error => {
           reject({
             message: error.response.data.message,
             code: error.response.status
           })
-        } else {
-          reject({ message: error });
-        }
-      });
-
+        });
     });
   };
 
-  makePostRequest(method, endpoint, data = {}, transformResponse) {
-
-    data = Object.assign(data, { api_key: this.key })
-
-    return new Promise((resolve, reject) => {
-
-      axios({
-        method: method,
-        url: `https://api.emailable.com/v1/${endpoint}`,
-        data: data,
-        transformResponse: transformResponse
-      })
-      .then(response => {
-        resolve(response.data);
-      })
-      .catch(error => {
-        reject({
-          message: error.response.data.message,
-          code: error.response.status
-        })
-      });
-
-    });
-  };
 }
 
 module.exports = Client;

--- a/lib/emailable.js
+++ b/lib/emailable.js
@@ -11,13 +11,11 @@ class Emailable {
   }
 
   verify(email, options = {}) {
-    var params = Object.assign({ email: email }, options);
-
-    return this.client.makeRequest('get', 'verify', params);
+    return this.client.makePostRequest('verify', { email: email, ...options });
   }
 
   account() {
-    return this.client.makeRequest('get', 'account');
+    return this.client.makeGetRequest('account');
   }
 
 }

--- a/test/account.spec.js
+++ b/test/account.spec.js
@@ -13,9 +13,16 @@ describe('emailable.account()', () => {
     });
   });
 
-  it('should return a 401 status code when an invalid API key', done => {
+  it('should return a 401 status code when no API key', done => {
     require('../lib/emailable')().account().catch(error => {
       expect(error.code).to.be.equal(401);
+      done();
+    });
+  });
+
+  it('should return a 403 status code when an invalid API key', done => {
+    require('../lib/emailable')('test_xxxxxxxxxx').account().catch(error => {
+      expect(error.code).to.be.equal(403);
       done();
     });
   });


### PR DESCRIPTION
- Remove unused `transformResponse` arg
- Renamed `makeRequest` to `makeGetRequest` since that is what it does and removed `method` arg from both request methods.
- Switched `verify` to use POST
- Switched authentication to use Authorization header